### PR TITLE
Revert "Implement instance of MonadBaseControl"

### DIFF
--- a/postgresql-transactional.cabal
+++ b/postgresql-transactional.cabal
@@ -20,9 +20,7 @@ library
   ghc-options: -Wall -Werror
   -- other-extensions:
   build-depends:       base >= 4 && < 5
-                     , monad-control >= 1.0
-                     , mtl
                      , postgresql-simple >= 0.4
-                     , transformers-base
+                     , mtl
   -- hs-source-dirs:
   default-language:    Haskell2010


### PR DESCRIPTION
Reverts helium/postgresql-transactional#3

It turns out that simply catching exceptions inside of a transaction does not continue the transaction in Postgres. If you continue executing statements while inside of a transaction that Postgres has aborted, you'll get a warning like this:

```
ERROR:  current transaction is aborted, commands ignored until end of transaction block
```

Catching exceptions inside of a `PGTransaction a` was the main goal of this functionality, and so I think until we have another need for it, that it simplifies the code and dependencies to simply remove this. It will be easy to add back if and when we have a need for `MonadBaseControl`.