### PR TITLE
Remove unused TransactionalStore typeclass.

### DIFF
--- a/src/Database/PostgreSQL/TransactionalStore.hs
+++ b/src/Database/PostgreSQL/TransactionalStore.hs
@@ -5,7 +5,6 @@
 
 module Database.PostgreSQL.TransactionalStore
     ( PGTransaction
-    , TransactionalStore (..)
     , runPGTransaction
     , runPGTransaction'
     , query
@@ -45,14 +44,6 @@ runPGTransaction' isolation (PGTransaction pgTrans) conn =
 
 runPGTransaction :: MonadIO m => PGTransaction a -> Postgres.Connection -> m a
 runPGTransaction = runPGTransaction' Postgres.Transaction.DefaultIsolationLevel
-
--- | Used to execute a `HeliumStore' `m' value inside of a transaction, with
--- connection/state `a', with effects in `n'.
-class TransactionalStore a m n where
-    runTransaction :: m b -> a -> n b
-
-instance MonadIO m => TransactionalStore Postgres.Connection PGTransaction m where
-    runTransaction = runPGTransaction
 
 -- | Issue an SQL query, taking a 'ToRow' input and yielding 'FromRow' outputs.
 query :: (ToRow input, FromRow output)


### PR DESCRIPTION
No one actually uses this typeclass, as it provides no mechanism
for retrieving the connection from a monadic context. We all just
write `transact` functions, which is a perfectly acceptable compromise.