### PR TITLE
Export PGTransactionT

### DIFF
--- a/postgresql-transactional.cabal
+++ b/postgresql-transactional.cabal
@@ -1,5 +1,5 @@
 name:                postgresql-transactional
-version:             1.0.0
+version:             1.1.0
 synopsis:            a transactional monad on top of postgresql-simple
 license:             MIT
 license-file:        LICENSE

--- a/src/Database/PostgreSQL/Transaction.hs
+++ b/src/Database/PostgreSQL/Transaction.hs
@@ -6,6 +6,7 @@
 
 module Database.PostgreSQL.Transaction
     ( PGTransaction
+    , PGTransactionT
     , runPGTransactionT
     , runPGTransactionT'
     , runPGTransactionIO


### PR DESCRIPTION
Whoops. Completely forgot to export `PGTransactionT`, which kinda defeats the purpose of the transformer in the first place. 