### PR TITLE
Add Database.PostgreSQL.Tagged.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Use of the `MonadBaseControl IO m` constraint leaves open the option of
 embedding additional effects with the `m` parameter, such as logging, state, or
 error-handling.
 
+We also provide a `PGTagged` monad transformer that is equivalent to `PGTransaction`, but includes 
+a phantom type in each relevant type signature that indicates whether said function has read-only 
+or write-enabled effects. This can be useful when dispatching read-only queries to Postgres replicas.
+
 ## About
 
 `postgresql-transactional` was extracted from a production Haskell project at
@@ -67,4 +71,4 @@ released to the public under the terms of the MIT license.
 
 ## Contributors
 
-Reid Draper wrote the original version. Patrick Thomson and Lane Seppala contributed documentation and infrastructure improvements.
+Reid Draper wrote the original version. Patrick Thomson wrote the tagged effects module. Lane Seppala contributed documentation and infrastructure improvements.

--- a/postgresql-transactional.cabal
+++ b/postgresql-transactional.cabal
@@ -22,6 +22,7 @@ source-repository head
 
 library
   exposed-modules:     Database.PostgreSQL.Transaction
+                     , Database.PostgreSQL.Tagged
   hs-source-dirs: src
   ghc-options: -Wall
   -- other-extensions:

--- a/postgresql-transactional.cabal
+++ b/postgresql-transactional.cabal
@@ -1,5 +1,5 @@
 name:                postgresql-transactional
-version:             1.2
+version:             1.2.0
 synopsis:            a transactional monad on top of postgresql-simple
 license:             MIT
 license-file:        LICENSE

--- a/postgresql-transactional.cabal
+++ b/postgresql-transactional.cabal
@@ -1,5 +1,5 @@
 name:                postgresql-transactional
-version:             1.1.1
+version:             1.2
 synopsis:            a transactional monad on top of postgresql-simple
 license:             MIT
 license-file:        LICENSE

--- a/src/Database/PostgreSQL/Tagged.hs
+++ b/src/Database/PostgreSQL/Tagged.hs
@@ -20,7 +20,7 @@ each function is tagged (using DataKinds over the 'Effect' type) with informatio
 as to whether it reads from or writes to the database. This is useful in conjunction
 with Postgres setups that are replicated over multiple machines.
 
-As with 'Database.PostgreSQL.Transaction', the parameter order is reversed when compared to the functions
+As with @Database.PostgreSQL.Transaction@, the parameter order is reversed when compared to the functions
 provided by postgresql-simple.
 
 -}
@@ -56,9 +56,13 @@ import           Database.PostgreSQL.Simple.FromRow
 import           Database.PostgreSQL.Simple.ToRow
 import qualified Database.PostgreSQL.Transaction      as T
 
+-- | Postgres queries are either read-only or writing-enabled.
+-- These values' kinds are used as phantom types in the 'PGTaggedT'
+-- monad transformer.
 data Effect = Read | Write
 
 -- | The tagged-effect Postgres monad transformer.
+-- The @e@ parameter must be either 'Read' or 'Write'.
 newtype PGTaggedT (e :: Effect) m a =
     PGTagged (T.PGTransactionT m a)
     deriving ( Functor
@@ -68,6 +72,7 @@ newtype PGTaggedT (e :: Effect) m a =
              , MonadReader Postgres.Connection
              , MonadIO)
 
+-- | A convenient alias for PGTaggedT values taking place in IO.
 type PGTaggedIO e a = PGTaggedT e IO a
 
 -- | Run a writing-oriented PGTagged transaction.

--- a/src/Database/PostgreSQL/Tagged.hs
+++ b/src/Database/PostgreSQL/Tagged.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImplicitPrelude            #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+
+{-|
+Module      : Database.PostgreSQL.Tagged
+Copyright   : (c) Helium Systems, Inc.
+License     : MIT
+Maintainer  : patrick@helium.com
+Stability   : experimental
+Portability : GHC
+
+This module is similar to @Database.PostgreSQL.Simple@, with one notable exception:
+each function is tagged (using DataKinds over the 'Effect' type) with information
+as to whether it reads from or writes to the database. This is useful in conjunction
+with Postgres setups that are replicated over multiple machines.
+
+As with 'Database.PostgreSQL.Transaction', the parameter order is reversed when compared to the functions
+provided by postgresql-simple.
+
+-}
+
+module Database.PostgreSQL.Tagged
+    ( Effect (..)
+    , PGTaggedT
+    , PGTaggedIO
+    , whileWriting
+    , runPGWrite
+    , runPGRead
+    , query
+    , query_
+    , execute
+    , executeOne
+    , executeMany
+    , returning
+    , queryHead
+    , queryOnly
+    , formatQuery
+    ) where
+
+#if __GLASGOW_HASKELL__ < 710
+import           Control.Applicative
+#endif
+import           Control.Monad.Reader
+import           Control.Monad.Trans.Control
+import           Data.Coerce
+import           Data.Int
+import qualified Database.PostgreSQL.Simple           as Postgres
+import           Database.PostgreSQL.Simple.FromField
+import           Database.PostgreSQL.Simple.FromRow
+import           Database.PostgreSQL.Simple.ToRow
+import qualified Database.PostgreSQL.Transaction      as T
+
+data Effect = Read | Write
+
+-- | The tagged-effect Postgres monad transformer.
+newtype PGTaggedT (e :: Effect) m a =
+    PGTagged (T.PGTransactionT m a)
+    deriving ( Functor
+             , Applicative
+             , Monad
+             , MonadTrans
+             , MonadReader Postgres.Connection
+             , MonadIO)
+
+type PGTaggedIO e a = PGTaggedT e IO a
+
+-- | Run a writing-oriented PGTagged transaction.
+runPGWrite :: MonadBaseControl IO m
+             => PGTaggedT 'Write m a
+             -> Postgres.Connection
+             -> m a
+runPGWrite = T.runPGTransactionT . coerce
+
+-- | Run a read-only PGTagged transaction. Actions such as
+-- these can take place on a read-only replica.
+runPGRead :: MonadBaseControl IO m
+             => PGTaggedT 'Read m a
+             -> Postgres.Connection
+             -> m a
+runPGRead = T.runPGTransactionT . coerce
+
+-- | Promote a reading operation to a writing operation.
+-- Note that there is no way to go the opposite direction
+-- (unless you use 'coerce'). This is by design: if you're
+-- writing, it's safe to read, but the converse does not
+-- necessarily hold true.
+whileWriting :: PGTaggedT 'Read m a -> PGTaggedT 'Write m a
+whileWriting = coerce
+
+-- | Run an individual query. (read operation)
+query :: (ToRow input, FromRow output, MonadIO m)
+      => input
+      -> Postgres.Query
+      -> PGTaggedT 'Read m [output]
+query i = PGTagged <$> T.query i
+
+-- | As 'query', but without arguments. (read operation)
+query_ :: (FromRow output, MonadIO m)
+       => Postgres.Query
+       -> PGTaggedT 'Read m [output]
+query_ = PGTagged <$> T.query_
+
+-- | As 'Database.PostgreSQL.Simple.execute'. (write operation)
+execute :: (ToRow input, MonadIO m)
+        => input
+        -> Postgres.Query
+        -> PGTaggedT 'Write m Int64
+execute i = PGTagged <$> T.execute i
+
+-- | As 'Database.PostgreSQL.Simple.executeMany'. (write operation)
+executeMany :: (ToRow input, MonadIO m)
+            => [input]
+            -> Postgres.Query
+            -> PGTaggedT 'Write m Int64
+executeMany is = PGTagged <$> T.executeMany is
+
+-- | As 'Database.PostgreSQL.Simple.returning'. (write operation)
+returning :: (ToRow input, FromRow output, MonadIO m)
+          => [input]
+          -> Postgres.Query
+          -> PGTaggedT 'Write m [output]
+returning is = PGTagged <$> T.returning is
+
+-- | As 'Database.PostgreSQL.Transaction.queryOnly'. (read operation)
+queryOnly :: (ToRow input, FromField f, MonadIO m)
+          => input
+          -> Postgres.Query
+          -> PGTaggedT 'Read m (Maybe f)
+queryOnly i = PGTagged <$> T.queryOnly i
+
+-- | As 'Database.PostgreSQL.Transaction.queryHead'. (read operation)
+queryHead :: (ToRow input, FromRow output, MonadIO m)
+          => input
+          -> Postgres.Query
+          -> PGTaggedT 'Read m (Maybe output)
+queryHead i = PGTagged <$> T.queryHead i
+
+-- | As 'Database.PostgreSQL.Transaction.executeOne'. (write operation)
+executeOne :: (ToRow input, MonadIO m)
+           => input
+           -> Postgres.Query
+           -> PGTaggedT 'Write m Bool
+executeOne i = PGTagged <$> T.executeOne i
+
+-- | As 'Database.PostgreSQL.Simple.formatQuery'. (neutral)
+formatQuery :: (ToRow input, MonadIO m)
+            => input
+            -> Postgres.Query
+            -> PGTaggedT e m Postgres.Query
+formatQuery i = PGTagged <$> T.formatQuery i

--- a/src/Database/PostgreSQL/Transaction.hs
+++ b/src/Database/PostgreSQL/Transaction.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImplicitPrelude            #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 
 {-|


### PR DESCRIPTION
This tagged-effect module allows you to represent the semantics of your
queries (i.e. whether they are idempotent or not) in the Haskell type
system. This can be useful when dealing with Postgres replicas:
read-only queries can be farmed out to replicas, whereas queries that
write to the database can be dispatched directly to the primary.