### PR TITLE
Handle a failed transaction error during cleanup of savepoints

### DIFF
--- a/postgresql-transactional.cabal
+++ b/postgresql-transactional.cabal
@@ -1,5 +1,5 @@
 name:                postgresql-transactional
-version:             1.3.0
+version:             1.3.1
 synopsis:            a transactional monad on top of postgresql-simple
 license:             MIT
 license-file:        LICENSE.txt

--- a/src/Database/PostgreSQL/Transaction.hs
+++ b/src/Database/PostgreSQL/Transaction.hs
@@ -107,7 +107,8 @@ instance (MonadIO m, MonadThrow m, MonadMask m, MonadCatch m)
             -- remove them when they are no longer needed to save
             -- resources.
             cleanup = liftIO $ PT.releaseSavepoint conn sp `catch` \err ->
-                            if PT.isNoActiveTransactionError err
+                            if PT.isNoActiveTransactionError err 
+                            || PT.isFailedTransactionError err 
                                 then -- The transaction was aborted, so
                                      -- the savepoint was deleted. This
                                      -- is not important, so we catch


### PR DESCRIPTION
Current tests pass, should add a test that creates a failed transaction soon.